### PR TITLE
Descendant paths detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 
-- Initial implementation
+- Initial implementation - [#3]
 - Unit tests
 - Documentation
 - Changelog
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file. The format 
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: (https://semver.org/spec/v2.0.0.html
+[#3]: https://github.com/amercier/files-by-directory/pull/3
 [#4]: https://github.com/amercier/files-by-directory/pull/4
 [v0.1.0]: https://github.com/amercier/(https://github.com/amercier/files-by-directory/pull/4)/compare/v0.0.0...v0.1.0
 [unreleased]: https://github.com/amercier/(https://github.com/amercier/files-by-directory/pull/4)/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-(nothing)
+### Fixed
+
+- Improved descendant paths detection - see #4
 
 ## [v0.1.0] - 2018-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
-- Improved descendant paths detection - see #4
+- Improved descendant paths detection - [#4]
 
 ## [v0.1.0] - 2018-11-21
 
@@ -27,5 +27,6 @@ All notable changes to this project will be documented in this file. The format 
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: (https://semver.org/spec/v2.0.0.html
-[v0.1.0]: https://github.com/amercier/hiplog/compare/v0.0.0...v0.1.0
-[unreleased]: https://github.com/amercier/hiplog/compare/v0.1.0...HEAD
+[#4]: https://github.com/amercier/files-by-directory/pull/4
+[v0.1.0]: https://github.com/amercier/(https://github.com/amercier/files-by-directory/pull/4)/compare/v0.0.0...v0.1.0
+[unreleased]: https://github.com/amercier/(https://github.com/amercier/files-by-directory/pull/4)/compare/v0.1.0...HEAD

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "of"
   ],
   "dependencies": {
+    "escape-string-regexp": "^1.0.5",
     "regenerator-runtime": "^0.13.1"
   },
   "devDependencies": {

--- a/src/__snapshots__/files-by-directory.spec.js.snap
+++ b/src/__snapshots__/files-by-directory.spec.js.snap
@@ -33,7 +33,39 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory omits previously processed directories 1`] = `
+exports[`filesByDirectory omits descendant directory paths 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;
+
+exports[`filesByDirectory omits descendant directory paths 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;
+
+exports[`filesByDirectory omits descendant file paths 1`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -42,42 +74,28 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory omits previously processed files 1`] = `
+exports[`filesByDirectory omits descendant file paths 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory omits double directory paths 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory omits double file paths 1`] = `
 Array [
   Array [
     "fixture/level1/file1a",
-  ],
-]
-`;
-
-exports[`filesByDirectory omits previously processed nested directories 1`] = `
-Array [
-  Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
-    "fixture/level1/level2/file2a",
-    "fixture/level1/level2/file2b",
-    "fixture/level1/level2/link-to-directory",
-    "fixture/level1/level2/link-to-grand-parent-directory",
-    "fixture/level1/level2/link-to-parent-directory",
-  ],
-]
-`;
-
-exports[`filesByDirectory omits previously processed nested directories 2`] = `
-Array [
-  Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
-    "fixture/level1/level2/file2a",
-    "fixture/level1/level2/file2b",
-    "fixture/level1/level2/link-to-directory",
-    "fixture/level1/level2/link-to-grand-parent-directory",
-    "fixture/level1/level2/link-to-parent-directory",
   ],
 ]
 `;

--- a/src/file.js
+++ b/src/file.js
@@ -50,20 +50,14 @@ export default class File {
    *
    * @async
    * @generator
-   * @param {string[]} Array of already processed path
    * @yields {Promise<File[]>} Generates one array of File instances per directory.
    */
-  async *getFilesByDirectory(processedPaths = []) {
-    if (processedPaths.indexOf(this.path) !== -1) {
-      return;
-    }
-    processedPaths.push(this.path);
-
+  async *getFilesByDirectory() {
     if (this.isDirectory) {
       const files = [];
       for await (const child of this.getChildren()) {
         if (child.isDirectory) {
-          yield* child.getFilesByDirectory(processedPaths);
+          yield* child.getFilesByDirectory();
         } else {
           files.push(child);
         }

--- a/src/files-by-directory.js
+++ b/src/files-by-directory.js
@@ -1,5 +1,5 @@
 import regeneratorRuntime from 'regenerator-runtime';
-import { asyncMap, asyncFlattenMap, values } from './async';
+import { asyncMap, asyncFlattenMap } from './async';
 import File from './file';
 import { isDescendant } from './path';
 
@@ -21,13 +21,8 @@ export default async function* filesByDirectory(paths) {
     (path, i) => !paths.some((other, j) => (j > i && path === other) || isDescendant(path, other)),
   );
 
-  const unordered = await values(File.fromPaths(cleanPaths));
-  const ordered = [
-    ...unordered.filter(file => file.isDirectory),
-    ...unordered.filter(file => !file.isDirectory),
-  ];
-
-  yield* asyncMap(asyncFlattenMap(ordered, file => file.getFilesByDirectory()), files =>
-    files.map(file => file.path),
+  yield* asyncMap(
+    asyncFlattenMap(File.fromPaths(cleanPaths), file => file.getFilesByDirectory()),
+    files => files.map(file => file.path),
   );
 }

--- a/src/files-by-directory.js
+++ b/src/files-by-directory.js
@@ -1,6 +1,8 @@
 import regeneratorRuntime from 'regenerator-runtime';
 import { asyncMap, asyncFlattenMap, values } from './async';
 import File from './file';
+import { isDescendant } from './path';
+
 /**
  * Generate array of file paths for each directory, recursively.
  *
@@ -14,15 +16,18 @@ import File from './file';
  * @yields {Promise<File[]>} Generates one array of File instances per directory.
  */
 export default async function* filesByDirectory(paths) {
-  const unordered = await values(File.fromPaths(paths));
+  // Remove doubles and descendant paths
+  const cleanPaths = paths.filter(
+    (path, i) => !paths.some((other, j) => (j > i && path === other) || isDescendant(path, other)),
+  );
+
+  const unordered = await values(File.fromPaths(cleanPaths));
   const ordered = [
     ...unordered.filter(file => file.isDirectory),
     ...unordered.filter(file => !file.isDirectory),
   ];
-  const processedPaths = [];
 
-  yield* asyncMap(
-    asyncFlattenMap(ordered, file => file.getFilesByDirectory(processedPaths)),
-    files => files.map(file => file.path),
+  yield* asyncMap(asyncFlattenMap(ordered, file => file.getFilesByDirectory()), files =>
+    files.map(file => file.path),
   );
 }

--- a/src/files-by-directory.spec.js
+++ b/src/files-by-directory.spec.js
@@ -23,11 +23,7 @@ describe('filesByDirectory', () => {
     expect(await values(getFilesByDirectory([existingDirectory]))).toMatchSnapshot();
   });
 
-  it('omits previously processed files', async () => {
-    expect(await values(getFilesByDirectory([existingFile, existingFile]))).toMatchSnapshot();
-  });
-
-  it('omits previously processed directories', async () => {
+  it('omits double directory paths', async () => {
     expect(
       await values(
         getFilesByDirectory([directoryWithoutSubdirectories, directoryWithoutSubdirectories]),
@@ -35,13 +31,36 @@ describe('filesByDirectory', () => {
     ).toMatchSnapshot();
   });
 
-  it('omits previously processed nested directories', async () => {
+  it('omits double file paths', async () => {
+    expect(await values(getFilesByDirectory([existingFile, existingFile]))).toMatchSnapshot();
+  });
+
+  it('omits descendant directory paths', async () => {
     expect(
       await values(getFilesByDirectory([existingDirectory, directoryWithoutSubdirectories])),
     ).toMatchSnapshot();
 
     expect(
       await values(getFilesByDirectory([directoryWithoutSubdirectories, existingDirectory])),
+    ).toMatchSnapshot();
+  });
+
+  it('omits descendant file paths', async () => {
+    expect(
+      await values(
+        getFilesByDirectory([
+          `${directoryWithoutSubdirectories}/file3a`,
+          directoryWithoutSubdirectories,
+        ]),
+      ),
+    ).toMatchSnapshot();
+    expect(
+      await values(
+        getFilesByDirectory([
+          directoryWithoutSubdirectories,
+          `${directoryWithoutSubdirectories}/file3a`,
+        ]),
+      ),
     ).toMatchSnapshot();
   });
 });

--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,35 @@
+import escape from 'escape-string-regexp';
+import { relative, sep } from 'path';
+
+/**
+ * Regular expression that matches all "ascendant" paths:
+ * - '..'
+ * - '../..'
+ * - '../../..'
+ * - etc.
+ *
+ * @type {RegExp}
+ */
+export const ascendanceRegExp = new RegExp(`^(${escape('..')}${escape(sep)})*${escape('..')}$`);
+
+/**
+ * Whether a path is an ascendant of another one.
+ *
+ * @param {string} subject ascendant path.
+ * @param {string} descendant descendant path.
+ * @returns {boolean} `true` if `subject` is an ascendant of `descendant`, `false` otherwise.
+ */
+export function isAscendant(subject, descendant) {
+  return ascendanceRegExp.test(relative(descendant, subject));
+}
+
+/**
+ * Whether a path is an descendant of another one.
+ *
+ * @param {string} subject descendant path.
+ * @param {string} ascendant ascendant path.
+ * @returns {boolean} `true` if `subject` is an ascendant of `ascendant`, `false` otherwise.
+ */
+export function isDescendant(subject, ascendant) {
+  return isAscendant(ascendant, subject);
+}

--- a/src/path.js
+++ b/src/path.js
@@ -33,3 +33,16 @@ export function isAscendant(subject, descendant) {
 export function isDescendant(subject, ascendant) {
   return isAscendant(ascendant, subject);
 }
+
+/**
+ * Whether a path is unique and does not have any ascendant within an array of paths.
+ *
+ * @param {string} path A path.
+ * @param {number} index Index of `path` with
+ * @param {string[]} paths Array of paths.
+ * @returns {boolean} `true` if `path` is both unique and do not have any ascendant within `paths`,
+ * `false` otherwise.
+ */
+export function isUniqueAndNotDescendant(path, index, paths) {
+  return paths.indexOf(path) === index && !paths.some(p => isAscendant(p, path));
+}

--- a/src/path.spec.js
+++ b/src/path.spec.js
@@ -1,0 +1,87 @@
+import { ascendanceRegExp, isAscendant, isDescendant } from './path';
+
+describe('ascendanceRegExp', () => {
+  it('is a RegExp', () => {
+    expect(ascendanceRegExp).toBeInstanceOf(RegExp);
+  });
+
+  it('matches ascendant paths', () => {
+    expect(ascendanceRegExp.test('..')).toBe(true);
+    expect(ascendanceRegExp.test('../..')).toBe(true);
+  });
+
+  it("doesn't match non-ascendant paths", () => {
+    expect(ascendanceRegExp.test('../foo')).toBe(false);
+    expect(ascendanceRegExp.test('../../foo')).toBe(false);
+    expect(ascendanceRegExp.test('')).toBe(false);
+    expect(ascendanceRegExp.test('foo')).toBe(false);
+  });
+});
+
+describe('isAscendant', () => {
+  it('is a function', () => {
+    expect(isAscendant).toBeFunction();
+  });
+
+  it('returns false when paths are identical', () => {
+    expect(isAscendant('/foo/bar', '/foo/bar')).toBe(false);
+  });
+
+  it('returns false when subject is a child', () => {
+    expect(isAscendant('/foo/bar', '/foo')).toBe(false);
+  });
+
+  it('returns false when subject is a grand-child', () => {
+    expect(isAscendant('/foo/bar/baz', '/foo')).toBe(false);
+  });
+
+  it('returns true when subject is the parent', () => {
+    expect(isAscendant('/foo', '/foo/bar')).toBe(true);
+  });
+
+  it('returns true when subject is the grand-parent', () => {
+    expect(isAscendant('/foo', '/foo/bar/baz')).toBe(true);
+  });
+
+  it('returns false when subject is a sibling', () => {
+    expect(isAscendant('/foo/bar', '/foo/baz')).toBe(false);
+  });
+
+  it('returns false when subject has different root', () => {
+    expect(isAscendant('/foo/bar', '/baz/bar')).toBe(false);
+  });
+});
+
+describe('isDescendant', () => {
+  it('is a function', () => {
+    expect(isDescendant).toBeFunction();
+  });
+
+  it('returns false when paths are identical', () => {
+    expect(isDescendant('/foo/bar', '/foo/bar')).toBe(false);
+  });
+
+  it('returns true when subject is a child', () => {
+    expect(isDescendant('/foo/bar', '/foo')).toBe(true);
+  });
+
+  it('returns true when subject is a grand-child', () => {
+    expect(isDescendant('/foo/bar/baz', '/foo')).toBe(true);
+  });
+
+  it('returns false when subject is the parent', () => {
+    expect(isDescendant('/foo', '/foo/bar')).toBe(false);
+  });
+
+  it('returns false when subject is the grand-parent', () => {
+    expect(isDescendant('/foo', '/foo/bar/baz')).toBe(false);
+  });
+
+  it('returns false when subject is a sibling', () => {
+    expect(isDescendant('/foo/bar', '/foo/baz')).toBe(false);
+  });
+
+  it('returns false when subject has different root', () => {
+    expect(isDescendant('/foo/bar', '/baz/bar')).toBe(false);
+  });
+});

--- a/src/path.spec.js
+++ b/src/path.spec.js
@@ -1,4 +1,4 @@
-import { ascendanceRegExp, isAscendant, isDescendant } from './path';
+import { ascendanceRegExp, isAscendant, isDescendant, isUniqueAndNotDescendant } from './path';
 
 describe('ascendanceRegExp', () => {
   it('is a RegExp', () => {
@@ -83,5 +83,39 @@ describe('isDescendant', () => {
 
   it('returns false when subject has different root', () => {
     expect(isDescendant('/foo/bar', '/baz/bar')).toBe(false);
+  });
+});
+
+describe('isUniqueAndNotDescendant', () => {
+  it('is a function', () => {
+    expect(isUniqueAndNotDescendant).toBeFunction();
+  });
+
+  it('returns true for the first double', () => {
+    expect(isUniqueAndNotDescendant('foo', 0, ['foo', 'bar', 'foo', 'baz'])).toBe(true);
+  });
+
+  it('returns false for the second double', () => {
+    expect(isUniqueAndNotDescendant('foo', 2, ['foo', 'bar', 'foo', 'baz'])).toBe(false);
+  });
+
+  it('returns false for a descendant after an ascendant', () => {
+    expect(isUniqueAndNotDescendant('foo/bar', 1, ['foo', 'foo/bar', 'baz'])).toBe(false);
+  });
+
+  it('returns false for a descendant before an ascendant', () => {
+    expect(isUniqueAndNotDescendant('foo/bar', 0, ['foo/bar', 'foo', 'baz'])).toBe(false);
+  });
+
+  it('returns true for an ascendant after an descendant', () => {
+    expect(isUniqueAndNotDescendant('foo', 1, ['foo/bar', 'foo', 'baz'])).toBe(true);
+  });
+
+  it('returns true for an ascendant before an descendant', () => {
+    expect(isUniqueAndNotDescendant('foo', 0, ['foo', 'foo/bar', 'baz'])).toBe(true);
+  });
+
+  it('returns true for a unique path', () => {
+    expect(isUniqueAndNotDescendant('bar', 1, ['foo', 'bar', 'baz'])).toBe(true);
   });
 });


### PR DESCRIPTION
# Summary

This PR improves double/descendant path detection in `filesByDirectory()`.

# Problem

```bash
# Directory structure:
root
├── file1
└── file2
```

```js
for await (const files of filesByDirectory(['root', 'root/file1'])) {
  console.log(files);
}
```

## Expected result

```
['root/file1', 'root/file2']
```

## Actual result

```
['root/file1', 'root/file2']
['root/file1']
```