### PR TITLE
Group passed files together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-(nothing)
+### Fixed
+
+- Fixed passed paths to siblings files not being grouping together - [#5]
 
 ## [v0.1.1] - 2018-11-22
 
@@ -33,6 +35,7 @@ All notable changes to this project will be documented in this file. The format 
 [semantic versioning]: (https://semver.org/spec/v2.0.0.html
 [#3]: https://github.com/amercier/files-by-directory/pull/3
 [#4]: https://github.com/amercier/files-by-directory/pull/4
+[#5]: https://github.com/amercier/files-by-directory/pull/5
 [v0.1.0]: https://github.com/amercier/files-by-directory/compare/v0.0.0...v0.1.0
 [v0.1.1]: https://github.com/amercier/files-by-directory/compare/v0.1.0...v0.1.1
 [unreleased]: https://github.com/amercier/files-by-directory/compare/v0.1.1...HEAD

--- a/fixture/index.js
+++ b/fixture/index.js
@@ -3,10 +3,24 @@ import { join, relative } from 'path';
 const cwd = process.cwd();
 
 export const fixture = (...args) => join(relative(cwd, __dirname), 'level1', ...args);
+export const level2 = fixture('level2');
+export const level2Files = [
+  fixture('level2', 'file2a'),
+  fixture('level2', 'file2b'),
+  fixture('level2', 'link-to-directory'),
+  fixture('level2', 'link-to-grand-parent-directory'),
+  fixture('level2', 'link-to-parent-directory'),
+];
+export const level3 = fixture('level2', 'level3');
+export const level3Files = [
+  fixture('level2', 'level3', 'file3a'),
+  fixture('level2', 'level3', 'file3b'),
+];
+export const level2RegularFiles = [fixture('level2', 'file2a'), fixture('level2', 'file2b')];
 export const existingFile = fixture('file1a');
-export const existingDirectory = fixture('level2');
+export const existingDirectory = level2;
 export const unexistingFile = fixture('unexisting-file');
 export const symlinkToExistingFile = fixture('link-to-sibling-file');
 export const symlinkToExistingDirectory = fixture('link-to-sibling-directory');
 export const symlinkToUnexistingFile = fixture('link-to-unexisting-file');
-export const directoryWithoutSubdirectories = fixture('level2', 'level3');
+export const directoryWithoutSubdirectories = level3;

--- a/src/__snapshots__/files-by-directory.spec.js.snap
+++ b/src/__snapshots__/files-by-directory.spec.js.snap
@@ -33,6 +33,47 @@ Array [
 ]
 `;
 
+exports[`filesByDirectory groups regular files by parent path 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory groups regular files by parent path 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory groups regular files by parent path 3`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;
+
 exports[`filesByDirectory omits descendant directory paths 1`] = `
 Array [
   Array [

--- a/src/files-by-directory.js
+++ b/src/files-by-directory.js
@@ -1,7 +1,40 @@
+import { dirname } from 'path';
 import regeneratorRuntime from 'regenerator-runtime';
-import { asyncMap, asyncFlattenMap } from './async';
+import { asyncMap } from './async';
 import File from './file';
 import { isUniqueAndNotDescendant } from './path';
+
+/**
+ * Generate array of File instances for each directory, recursively.
+ *
+ * Process directories first, then files. If multiple files belong to the same directory, they are
+ * grouped together. If a path is encountered twice, it is only generated once. Symbolic links are
+ * treated as regular files, even though they link to directories.
+ *
+ * @async
+ * @generator
+ * @param {string[]} paths Paths to files or directories.
+ * @return {AsyncIterator<File[]>} Generates one array of File instances per directory.
+ */
+async function* fileObjectsByDirectory(paths) {
+  const regularFiles = {};
+
+  for await (const file of File.fromPaths(paths.filter(isUniqueAndNotDescendant))) {
+    if (file.isDirectory) {
+      yield* file.getFilesByDirectory();
+    } else {
+      const parent = dirname(file.path);
+      if (!regularFiles[parent]) {
+        regularFiles[parent] = [];
+      }
+      regularFiles[parent].push(file);
+    }
+  }
+
+  for (const files of Object.values(regularFiles)) {
+    yield files;
+  }
+}
 
 /**
  * Generate array of file paths for each directory, recursively.
@@ -13,13 +46,8 @@ import { isUniqueAndNotDescendant } from './path';
  * @async
  * @generator
  * @param {string[]} paths Paths to files or directories.
- * @yields {Promise<File[]>} Generates one array of File instances per directory.
+ * @return {AsyncIterator<string[]>} Generates one array of file paths per directory.
  */
 export default async function* filesByDirectory(paths) {
-  const filesIterator = asyncFlattenMap(
-    File.fromPaths(paths.filter(isUniqueAndNotDescendant)),
-    file => file.getFilesByDirectory(),
-  );
-
-  yield* asyncMap(filesIterator, files => files.map(file => file.path));
+  yield* asyncMap(fileObjectsByDirectory(paths), files => files.map(file => file.path));
 }

--- a/src/files-by-directory.spec.js
+++ b/src/files-by-directory.spec.js
@@ -1,7 +1,15 @@
 import '@babel/polyfill'; // Required for NodeJS < 10
 import { values } from './async';
 import getFilesByDirectory from './files-by-directory';
-import { existingFile, existingDirectory, directoryWithoutSubdirectories } from '../fixture';
+import {
+  existingFile,
+  existingDirectory,
+  directoryWithoutSubdirectories,
+  level2,
+  level2Files,
+  level3,
+  level3Files,
+} from '../fixture';
 
 /** @test {filesByDirectory} */
 describe('filesByDirectory', () => {
@@ -24,11 +32,7 @@ describe('filesByDirectory', () => {
   });
 
   it('omits double directory paths', async () => {
-    expect(
-      await values(
-        getFilesByDirectory([directoryWithoutSubdirectories, directoryWithoutSubdirectories]),
-      ),
-    ).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([level3, level3]))).toMatchSnapshot();
   });
 
   it('omits double file paths', async () => {
@@ -36,31 +40,18 @@ describe('filesByDirectory', () => {
   });
 
   it('omits descendant directory paths', async () => {
-    expect(
-      await values(getFilesByDirectory([existingDirectory, directoryWithoutSubdirectories])),
-    ).toMatchSnapshot();
-
-    expect(
-      await values(getFilesByDirectory([directoryWithoutSubdirectories, existingDirectory])),
-    ).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([level2, level3]))).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([level3, level2]))).toMatchSnapshot();
   });
 
   it('omits descendant file paths', async () => {
-    expect(
-      await values(
-        getFilesByDirectory([
-          `${directoryWithoutSubdirectories}/file3a`,
-          directoryWithoutSubdirectories,
-        ]),
-      ),
-    ).toMatchSnapshot();
-    expect(
-      await values(
-        getFilesByDirectory([
-          directoryWithoutSubdirectories,
-          `${directoryWithoutSubdirectories}/file3a`,
-        ]),
-      ),
-    ).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([level3, level3Files[0]]))).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([level3Files[0], level3]))).toMatchSnapshot();
+  });
+
+  it('groups regular files by parent path', async () => {
+    expect(await values(getFilesByDirectory(level3Files))).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([...level2Files, ...level3Files]))).toMatchSnapshot();
+    expect(await values(getFilesByDirectory([...level3Files, ...level2Files]))).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
# Summary

This PR groups sibling paths together in `filesByDirectory()`.

## Problem

```bash
# Directory structure:
dir
├── file1
└── file2
```

```javascript
for await (const files of filesByDirectory(['dir/file1', 'dir/file2'])) {
  console.log(files);
}
```

## Expected result

```
['dir/file1', 'dir/file2']
```

## Actual result

```
['dir/file1']
['dir/file2']
```