### PR TITLE
excludeSymlinks option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-(nothing)
+### Added
+
+- `excludeSymlinks` option - [#7]
 
 ## [v0.1.2] - 2018-11-22
 
@@ -40,6 +42,7 @@ All notable changes to this project will be documented in this file. The format 
 [#3]: https://github.com/amercier/files-by-directory/pull/3
 [#4]: https://github.com/amercier/files-by-directory/pull/4
 [#5]: https://github.com/amercier/files-by-directory/pull/5
+[#7]: https://github.com/amercier/files-by-directory/pull/7
 [v0.1.0]: https://github.com/amercier/files-by-directory/compare/v0.0.0...v0.1.0
 [v0.1.1]: https://github.com/amercier/files-by-directory/compare/v0.1.0...v0.1.1
 [v0.1.1]: https://github.com/amercier/files-by-directory/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install --save files-by-directory
 
 ## API
 
-### `filesByDirectory(paths: string[]): AsyncIterator<string[]>`
+### `filesByDirectory(paths: string[], options = {}): AsyncIterator<string[]>`
 
 Scan directories recursively, and generate 1 array per directory, containing the file paths.
 
@@ -76,6 +76,35 @@ for await (const files of filesByDirectory(['level1'])) {
 
 - If a path is encountered twice, it is only generated once.
 - Symbolic links are treated as regular files, even though they link to directories.
+
+#### `options.excludeSymlinks` (default: `false`)
+
+When set to `true`, excludes symbolic links from results:
+
+```bash
+# Directory structure:
+level1
+├── level2a
+│   ├── file2a
+│   └── file2b
+├── level2b -> level2a
+├── file1a
+└── file1b -> file1a
+```
+
+```js
+for await (const files of filesByDirectory(['level1']/*, { excludeSymlinks: false }*/} )) {
+  console.log(files);
+}
+// [ 'level1/level2b', 'level1/file1a', 'level1/file1b' ]
+// [ 'level2a/file2a', 'level2a/file2b' ]
+
+for await (const files of filesByDirectory(['level1'], { excludeSymlinks: true })) {
+  console.log(files);
+}
+// [ 'level1/file1a', 'level1/file1b' ]
+// [ 'level2a/file2a', 'level2a/file2b' ]
+```
 
 ## Asynchronous iteration
 

--- a/src/__snapshots__/async.spec.js.snap
+++ b/src/__snapshots__/async.spec.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`asyncFilter when iterable is a a synchronous iterator and filter is a synchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
+exports[`asyncFilter when iterable is a a synchronous iterator and filter is an asynchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
+exports[`asyncFilter when iterable is a an array and filter is a synchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
+exports[`asyncFilter when iterable is a an array and filter is an asynchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
+exports[`asyncFilter when iterable is a an asynchronous iterator and filter is a synchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
+exports[`asyncFilter when iterable is a an asynchronous iterator and filter is an asynchronous function yields expected values 1`] = `
+Array [
+  "bar",
+  "baz",
+]
+`;
+
 exports[`asyncFlattenMap when iterable is a a synchronous iterator and fn is a synchronous generator yields expected values asynchronously 1`] = `"foo1"`;
 
 exports[`asyncFlattenMap when iterable is a a synchronous iterator and fn is a synchronous generator yields expected values asynchronously 2`] = `"foo2"`;

--- a/src/__snapshots__/file.spec.js.snap
+++ b/src/__snapshots__/file.spec.js.snap
@@ -107,7 +107,7 @@ Array [
 ]
 `;
 
-exports[`File getFilesByDirectory() generates asynchronously one array containing the file when file is an unexisting file 1`] = `
+exports[`File getFilesByDirectory() generates asynchronously one array containing the file when file is an non-existing file 1`] = `
 Array [
   Array [
     File {
@@ -313,7 +313,7 @@ File {
 }
 `;
 
-exports[`File static fromPath() resolves with and instance of File when symlink links to an existing directory 1`] = `
+exports[`File static fromPath() resolves with and instance of File when symlink links to a directory 1`] = `
 File {
   "isDirectory": false,
   "isSymbolicLink": true,
@@ -321,7 +321,7 @@ File {
 }
 `;
 
-exports[`File static fromPath() resolves with and instance of File when symlink links to an existing file 1`] = `
+exports[`File static fromPath() resolves with and instance of File when symlink links to a file 1`] = `
 File {
   "isDirectory": false,
   "isSymbolicLink": true,
@@ -329,7 +329,7 @@ File {
 }
 `;
 
-exports[`File static fromPath() resolves with and instance of File when symlink links to unexisting file 1`] = `
+exports[`File static fromPath() resolves with and instance of File when symlink links to non-existing file 1`] = `
 File {
   "isDirectory": false,
   "isSymbolicLink": true,
@@ -375,4 +375,134 @@ File {
   "isSymbolicLink": true,
   "path": "fixture/level1/link-to-unexisting-file",
 }
+`;
+
+exports[`File static readDir() generates asynchronously one File instance per child when path is a directory 1`] = `
+Array [
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2/level3/file3a",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2/level3/file3b",
+  },
+]
+`;
+
+exports[`File static readDir() generates asynchronously one File instance per child when path is a directory 2`] = `
+Array [
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2/file2a",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2/file2b",
+  },
+  File {
+    "isDirectory": true,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2/level3",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/level2/link-to-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/level2/link-to-grand-parent-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/level2/link-to-parent-directory",
+  },
+]
+`;
+
+exports[`File static readDir() generates asynchronously one File instance per child when path is a directory 3`] = `
+Array [
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/file1a",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/file1b",
+  },
+  File {
+    "isDirectory": true,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/level2",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-descendant-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-descendant-file",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-sibling-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-sibling-file",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-unexisting-file",
+  },
+]
+`;
+
+exports[`File static readDir() generates asynchronously one File instance per child when path links to a directory 1`] = `
+Array [
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/link-to-sibling-directory/file2a",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/link-to-sibling-directory/file2b",
+  },
+  File {
+    "isDirectory": true,
+    "isSymbolicLink": false,
+    "path": "fixture/level1/link-to-sibling-directory/level3",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-sibling-directory/link-to-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-sibling-directory/link-to-grand-parent-directory",
+  },
+  File {
+    "isDirectory": false,
+    "isSymbolicLink": true,
+    "path": "fixture/level1/link-to-sibling-directory/link-to-parent-directory",
+  },
+]
 `;

--- a/src/__snapshots__/file.spec.js.snap
+++ b/src/__snapshots__/file.spec.js.snap
@@ -4,34 +4,42 @@ exports[`File getChildren() generates asynchronously one File instance per child
 Array [
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/file1a",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/file1b",
   },
   File {
     "isDirectory": true,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/link-to-descendant-directory",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/link-to-descendant-file",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/link-to-sibling-directory",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/link-to-sibling-file",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/link-to-unexisting-file",
   },
 ]
@@ -41,26 +49,32 @@ exports[`File getChildren() generates asynchronously one File instance per child
 Array [
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2/file2a",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2/file2b",
   },
   File {
     "isDirectory": true,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2/level3",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/level2/link-to-directory",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/level2/link-to-grand-parent-directory",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": true,
     "path": "fixture/level1/level2/link-to-parent-directory",
   },
 ]
@@ -70,10 +84,12 @@ exports[`File getChildren() generates asynchronously one File instance per child
 Array [
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2/level3/file3a",
   },
   File {
     "isDirectory": false,
+    "isSymbolicLink": false,
     "path": "fixture/level1/level2/level3/file3b",
   },
 ]
@@ -84,6 +100,7 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/file1a",
     },
   ],
@@ -95,6 +112,7 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/unexisting-file",
     },
   ],
@@ -106,6 +124,7 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-sibling-file",
     },
   ],
@@ -117,6 +136,7 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-sibling-file",
     },
   ],
@@ -128,6 +148,7 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-unexisting-file",
     },
   ],
@@ -139,10 +160,12 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3b",
     },
   ],
@@ -154,32 +177,39 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3b",
     },
   ],
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/file2a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/file2b",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-grand-parent-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-parent-directory",
     },
   ],
@@ -191,62 +221,76 @@ Array [
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/level3/file3b",
     },
   ],
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/file2a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/level2/file2b",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-grand-parent-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-parent-directory",
     },
   ],
   Array [
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/file1a",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": false,
       "path": "fixture/level1/file1b",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-descendant-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-descendant-file",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-sibling-directory",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-sibling-file",
     },
     File {
       "isDirectory": false,
+      "isSymbolicLink": true,
       "path": "fixture/level1/link-to-unexisting-file",
     },
   ],
@@ -256,6 +300,7 @@ Array [
 exports[`File static fromPath() resolves with an instance of File when file is a directory 1`] = `
 File {
   "isDirectory": true,
+  "isSymbolicLink": false,
   "path": "fixture/level1/level2",
 }
 `;
@@ -263,6 +308,7 @@ File {
 exports[`File static fromPath() resolves with an instance of File when file is a file 1`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": false,
   "path": "fixture/level1/file1a",
 }
 `;
@@ -270,6 +316,7 @@ File {
 exports[`File static fromPath() resolves with and instance of File when symlink links to an existing directory 1`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-sibling-directory",
 }
 `;
@@ -277,6 +324,7 @@ File {
 exports[`File static fromPath() resolves with and instance of File when symlink links to an existing file 1`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-sibling-file",
 }
 `;
@@ -284,6 +332,7 @@ File {
 exports[`File static fromPath() resolves with and instance of File when symlink links to unexisting file 1`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-unexisting-file",
 }
 `;
@@ -291,6 +340,7 @@ File {
 exports[`File static fromPaths() generates instances of File asynchronously 1`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": false,
   "path": "fixture/level1/file1a",
 }
 `;
@@ -298,6 +348,7 @@ File {
 exports[`File static fromPaths() generates instances of File asynchronously 2`] = `
 File {
   "isDirectory": true,
+  "isSymbolicLink": false,
   "path": "fixture/level1/level2",
 }
 `;
@@ -305,6 +356,7 @@ File {
 exports[`File static fromPaths() generates instances of File asynchronously 3`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-sibling-file",
 }
 `;
@@ -312,6 +364,7 @@ File {
 exports[`File static fromPaths() generates instances of File asynchronously 4`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-sibling-directory",
 }
 `;
@@ -319,6 +372,7 @@ File {
 exports[`File static fromPaths() generates instances of File asynchronously 5`] = `
 File {
   "isDirectory": false,
+  "isSymbolicLink": true,
   "path": "fixture/level1/link-to-unexisting-file",
 }
 `;

--- a/src/__snapshots__/files-by-directory.spec.js.snap
+++ b/src/__snapshots__/files-by-directory.spec.js.snap
@@ -140,3 +140,121 @@ Array [
   ],
 ]
 `;
+
+exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 3`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+  Array [
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 3`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+    "fixture/level1/link-to-descendant-directory",
+    "fixture/level1/link-to-descendant-file",
+    "fixture/level1/link-to-sibling-directory",
+    "fixture/level1/link-to-sibling-file",
+    "fixture/level1/link-to-unexisting-file",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;

--- a/src/async.js
+++ b/src/async.js
@@ -21,9 +21,10 @@ export function promisify(fn) {
  *
  * @async
  * @generator
- * @param {Iterable} iterable Synchronous or asynchronous iterable.
- * @param {Function} fn Synchronous or asynchronous function.
- * @returns {Iterator} An asynchronous iterator that yields each value returned from `fn(iterable[i])`.
+ * @param {Iterable<T>} iterable Synchronous or asynchronous iterable.
+ * @param {Function: T => U} fn Synchronous or asynchronous function.
+ * @returns {AsyncIterator<U>} An asynchronous iterator that yields value returned by `fn` applied to
+ * each element of `iterable`.
  */
 export async function* asyncMap(iterable, fn) {
   for await (const value of iterable) {
@@ -32,13 +33,32 @@ export async function* asyncMap(iterable, fn) {
 }
 
 /**
+ * Return an asynchronous generator that yields all elements from a given iterable that pass the
+ * test implemented by the provided function.
+ *
+ * @async
+ * @generator
+ * @param {Iterable<T>} iterable Synchronous or asynchronous iterable.
+ * @param {Function: T => boolean} filter Synchronous or asynchronous function.
+ * @returns {AsyncIterator<T>} An asynchronous iterator that yields values from `iterable` where
+ * `filter` return a truthy value.
+ */
+export async function* asyncFilter(iterable, filter) {
+  for await (const value of iterable) {
+    if (await filter(value)) {
+      yield value;
+    }
+  }
+}
+
+/**
  * Apply a given generator to each element of a given iterable, and re-yield every yielded values.
  *
  * @async
  * @generator
- * @param {Iterable} iterable Synchronous or asynchronous iterable.
- * @param {Function} generator Synchronous or asynchronous generator function.
- * @returns {Promise} An asynchronous iterator that re-yields each value yielded by `generator(iterable[i])`.
+ * @param {Iterable<T>} iterable Synchronous or asynchronous iterable.
+ * @param {Function: T => Iterable<U>} generator Synchronous or asynchronous generator function.
+ * @returns {AsyncIterator<U>} An asynchronous iterator that re-yields each value yielded by `generator(iterable[i])`.
  */
 export async function* asyncFlattenMap(iterable, generator) {
   for await (const value of iterable) {
@@ -49,8 +69,8 @@ export async function* asyncFlattenMap(iterable, generator) {
 /**
  * Get all values from an iterable.
  *
- * @param {Iterable} iterable Synchronous or asynchronous iterable.
- * @returns {Promise} A Promise resolving to an array containing all yielded values.
+ * @param {Iterable<T>} iterable Synchronous or asynchronous iterable.
+ * @returns {Promise<T[]>} A Promise resolving to an array containing all yielded values.
  */
 export async function values(iterable) {
   const array = [];

--- a/src/async.spec.js
+++ b/src/async.spec.js
@@ -1,5 +1,5 @@
 import '@babel/polyfill'; // Required for NodeJS < 10
-import { asyncFlattenMap, asyncMap, promisify, values } from './async';
+import { asyncFilter, asyncFlattenMap, asyncMap, promisify, values } from './async';
 
 const array = ['foo', 'bar', 'baz'];
 
@@ -88,6 +88,38 @@ describe('asyncMap', () => {
             for await (const item of asyncMap(getIterable(), fn)) {
               expect(item).toMatchSnapshot();
             }
+          });
+        });
+      });
+    });
+  });
+});
+
+/** @test {asyncFilter} */
+describe('asyncFilter', () => {
+  it('is a function', () => {
+    expect(asyncFilter).toBeFunction();
+  });
+
+  [
+    ['an array', () => ['foo', 'bar', 'baz']],
+    ['a synchronous iterator', synchronousGenerator],
+    ['an asynchronous iterator', asynchronousGenerator],
+  ].forEach(([whatIterable, getIterable]) => {
+    describe(`when iterable is a ${whatIterable}`, () => {
+      [
+        ['a synchronous function', str => str.startsWith('ba')],
+        ['an asynchronous function', async str => Promise.resolve(str.startsWith('ba'))],
+      ].forEach(([whatFilter, filter]) => {
+        describe(`and filter is ${whatFilter}`, () => {
+          it('returns an asynchronous iterator', () => {
+            const iterator = asyncFilter(getIterable(), filter);
+            expect(iterator.next).toBeFunction();
+            expect(iterator.next()).toBeInstanceOf(Promise);
+          });
+
+          it('yields expected values', async () => {
+            expect(await values(asyncFilter(getIterable(), filter))).toMatchSnapshot();
           });
         });
       });

--- a/src/file.js
+++ b/src/file.js
@@ -1,7 +1,7 @@
 import regeneratorRuntime from 'regenerator-runtime';
 import { join } from 'path';
 import { asyncMap } from './async';
-import { isDir, readDir } from './fs';
+import { lStat, readDir } from './fs';
 
 /**
  * File
@@ -13,10 +13,12 @@ export default class File {
    * @param {string} path Path to a file, directory, or symlink
    * @param {boolean} isDirectory Whether the file is a directory or not. Symbolic links to
    * directories are not considered directories.
+   * @param {boolean} isSymbolicLink Whether the file is a symbolic link.
    */
-  constructor(path, isDirectory) {
+  constructor(path, isDirectory, isSymbolicLink) {
     this.path = path;
     this.isDirectory = isDirectory;
+    this.isSymbolicLink = isSymbolicLink;
   }
 
   /**
@@ -80,7 +82,7 @@ export default class File {
    */
   static fromDirent(directory, dirent) {
     const path = join(directory, dirent.name);
-    return new File(path, dirent.isDirectory());
+    return new File(path, dirent.isDirectory(), dirent.isSymbolicLink());
   }
 
   /**
@@ -91,7 +93,8 @@ export default class File {
    * @returns {Promise<File>} An instance of File representing the file.
    */
   static async fromPath(path) {
-    return new File(path, await isDir(path));
+    const stats = await lStat(path);
+    return new File(path, stats.isDirectory(), stats.isSymbolicLink());
   }
 
   /**

--- a/src/file.js
+++ b/src/file.js
@@ -40,11 +40,7 @@ export default class File {
       throw new Error(`File is not a directory: ${this}`);
     }
 
-    yield* asyncMap(await readDir(this.path, { withFileTypes: true }), child =>
-      typeof child === 'string'
-        ? this.constructor.fromPath(join(this.path, child)) // withFileTypes requires Node 10+
-        : this.constructor.fromDirent(this.path, child),
-    );
+    yield* this.constructor.readDir(this.path);
   }
 
   /**
@@ -103,9 +99,23 @@ export default class File {
    * @async
    * @generator
    * @param {string[]} paths Paths of the file.
-   * @yields {Promise<File>} One instance of File per path.
+   * @returns {AsyncGenenerator<File>} One instance of File per path.
    */
   static fromPaths(paths) {
     return asyncMap(paths, this.fromPath);
+  }
+
+  /**
+   * Create instance of files from a directory path.
+   *
+   * @param {string} directory Directory path.
+   * @returns {AsyncGenenerator<File>} An asynchronous generator of files.
+   */
+  static async *readDir(directory) {
+    yield* asyncMap(await readDir(directory, { withFileTypes: true }), child =>
+      typeof child === 'string'
+        ? this.fromPath(join(directory, child)) // withFileTypes requires Node 10+
+        : this.fromDirent(directory, child),
+    );
   }
 }

--- a/src/file.spec.js
+++ b/src/file.spec.js
@@ -109,7 +109,7 @@ describe('File', () => {
       expect(await values(new File(...level1Args).getFilesByDirectory())).toMatchSnapshot();
     });
 
-    it('generates asynchronously one array containing the file when file is an unexisting file', async () => {
+    it('generates asynchronously one array containing the file when file is an non-existing file', async () => {
       expect(await values(new File(...unexistingFileArgs).getFilesByDirectory())).toMatchSnapshot();
     });
 
@@ -141,10 +141,10 @@ describe('File', () => {
     const file1aDirent = argsToDirent(file1aArgs);
     const level2Dirent = argsToDirent(level2Args);
     const level3Dirent = argsToDirent(level3Args);
+    const unexistingFileDirent = argsToDirent(unexistingFileArgs);
     const linkToSiblingDirectoryDirent = argsToDirent(linkToSiblingDirectoryArgs);
     const linkToSiblingFileDirent = argsToDirent(linkToSiblingFileArgs);
     const linkToUnexistingFileDirent = argsToDirent(linkToUnexistingFileArgs);
-    const unexistingFileDirent = argsToDirent(unexistingFileArgs);
 
     it('creates instances of File', () => {
       expect(File.fromDirent(level1, file1aDirent)).toBeInstanceOf(File);
@@ -154,26 +154,26 @@ describe('File', () => {
       expect(File.fromDirent(level1, file1aDirent).path).toBe(file1a);
       expect(File.fromDirent(level1, level2Dirent).path).toBe(level2);
       expect(File.fromDirent(level2, level3Dirent).path).toBe(level3);
+      expect(File.fromDirent(level1, unexistingFileDirent).path).toBe(unexistingFile);
+      expect(File.fromDirent(level1, linkToSiblingFileDirent).path).toBe(linkToSiblingFile);
       expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).path).toBe(
         linkToSiblingDirectory,
       );
-      expect(File.fromDirent(level1, linkToSiblingFileDirent).path).toBe(linkToSiblingFile);
       expect(File.fromDirent(level1, linkToUnexistingFileDirent).path).toBe(linkToUnexistingFile);
-      expect(File.fromDirent(level1, unexistingFileDirent).path).toBe(unexistingFile);
     });
 
     it('it uses given dirent to determine isDirectory', () => {
       expect(File.fromDirent(level1, file1aDirent).isDirectory).toBe(file1aArgs[1]);
       expect(File.fromDirent(level1, level2Dirent).isDirectory).toBe(level2Args[1]);
       expect(File.fromDirent(level2, level3Dirent).isDirectory).toBe(level3Args[1]);
-      expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).isDirectory).toBe(
-        linkToSiblingDirectoryArgs[1],
+      expect(File.fromDirent(level1, linkToUnexistingFileDirent).isDirectory).toBe(
+        linkToUnexistingFileArgs[1],
       );
       expect(File.fromDirent(level1, linkToSiblingFileDirent).isDirectory).toBe(
         linkToSiblingFileArgs[1],
       );
-      expect(File.fromDirent(level1, linkToUnexistingFileDirent).isDirectory).toBe(
-        linkToUnexistingFileArgs[1],
+      expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).isDirectory).toBe(
+        linkToSiblingDirectoryArgs[1],
       );
       expect(File.fromDirent(level1, unexistingFileDirent).isDirectory).toBe(unexistingFileArgs[1]);
     });
@@ -182,17 +182,17 @@ describe('File', () => {
       expect(File.fromDirent(level1, file1aDirent).isSymbolicLink).toBe(file1aArgs[2]);
       expect(File.fromDirent(level1, level2Dirent).isSymbolicLink).toBe(level2Args[2]);
       expect(File.fromDirent(level2, level3Dirent).isSymbolicLink).toBe(level3Args[2]);
-      expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).isSymbolicLink).toBe(
-        linkToSiblingDirectoryArgs[2],
+      expect(File.fromDirent(level1, unexistingFileDirent).isSymbolicLink).toBe(
+        unexistingFileArgs[2],
       );
       expect(File.fromDirent(level1, linkToSiblingFileDirent).isSymbolicLink).toBe(
         linkToSiblingFileArgs[2],
       );
+      expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).isSymbolicLink).toBe(
+        linkToSiblingDirectoryArgs[2],
+      );
       expect(File.fromDirent(level1, linkToUnexistingFileDirent).isSymbolicLink).toBe(
         linkToUnexistingFileArgs[2],
-      );
-      expect(File.fromDirent(level1, unexistingFileDirent).isSymbolicLink).toBe(
-        unexistingFileArgs[2],
       );
     });
   });
@@ -212,21 +212,21 @@ describe('File', () => {
       expect(await File.fromPath(file1a)).toMatchSnapshot();
     });
 
-    it('rejects when file is an unexisting file', async () => {
+    it('rejects when file is an non-existing file', async () => {
       await expect(File.fromPath(unexistingFile)).toReject();
     });
 
-    it('resolves with and instance of File when symlink links to an existing directory', async () => {
-      await expect(File.fromPath(linkToSiblingDirectory)).toResolve();
-      expect(await File.fromPath(linkToSiblingDirectory)).toMatchSnapshot();
-    });
-
-    it('resolves with and instance of File when symlink links to an existing file', async () => {
+    it('resolves with and instance of File when symlink links to a file', async () => {
       await expect(File.fromPath(linkToSiblingFile)).toResolve();
       expect(await File.fromPath(linkToSiblingFile)).toMatchSnapshot();
     });
 
-    it('resolves with and instance of File when symlink links to unexisting file', async () => {
+    it('resolves with and instance of File when symlink links to a directory', async () => {
+      await expect(File.fromPath(linkToSiblingDirectory)).toResolve();
+      expect(await File.fromPath(linkToSiblingDirectory)).toMatchSnapshot();
+    });
+
+    it('resolves with and instance of File when symlink links to non-existing file', async () => {
       await expect(File.fromPath(linkToUnexistingFile)).toResolve();
       expect(await File.fromPath(linkToUnexistingFile)).toMatchSnapshot();
     });
@@ -245,9 +245,37 @@ describe('File', () => {
       }
     });
 
-    it('generates a rejected Promise when an unexisting file is given', async () => {
+    it('generates a rejected Promise when an non-existing file is given', async () => {
       const iterator = File.fromPaths([unexistingFile]);
       await expect(iterator.next()).toReject();
+    });
+  });
+
+  describe('static readDir()', () => {
+    it('generates a rejected Promise when path is a file', async () => {
+      await expect(values(File.readDir(file1a))).toReject();
+    });
+
+    it('generates asynchronously one File instance per child when path is a directory', async () => {
+      expect(await values(File.readDir(level3))).toMatchSnapshot();
+      expect(await values(File.readDir(level2))).toMatchSnapshot();
+      expect(await values(File.readDir(level1))).toMatchSnapshot();
+    });
+
+    it('generates a rejected Promise when path is a non-existing file', async () => {
+      await expect(values(File.readDir(unexistingFile))).toReject();
+    });
+
+    it('generates a rejected Promise when path links to a file', async () => {
+      await expect(values(File.readDir(linkToSiblingFile))).toReject();
+    });
+
+    it('generates asynchronously one File instance per child when path links to a directory', async () => {
+      expect(await values(File.readDir(linkToSiblingDirectory))).toMatchSnapshot();
+    });
+
+    it('generates a rejected Promise when path links to a non-existing file', async () => {
+      await expect(values(File.readDir(linkToUnexistingFile))).toReject();
     });
   });
 });

--- a/src/file.spec.js
+++ b/src/file.spec.js
@@ -13,14 +13,14 @@ import {
   unexistingFile,
 } from '../fixture';
 
-const file1aArgs = [file1a, false];
-const level1Args = [level1, true];
-const level2Args = [level2, true];
-const level3Args = [level3, true];
-const linkToSiblingDirectoryArgs = [linkToSiblingDirectory, false];
-const linkToSiblingFileArgs = [linkToSiblingFile, false];
-const linkToUnexistingFileArgs = [linkToUnexistingFile, false];
-const unexistingFileArgs = [unexistingFile, false];
+const file1aArgs = [file1a, false, false];
+const level1Args = [level1, true, false];
+const level2Args = [level2, true, false];
+const level3Args = [level3, true, false];
+const linkToSiblingDirectoryArgs = [linkToSiblingDirectory, false, true];
+const linkToSiblingFileArgs = [linkToSiblingFile, false, true];
+const linkToUnexistingFileArgs = [linkToUnexistingFile, false, true];
+const unexistingFileArgs = [unexistingFile, false, false];
 
 describe('File', () => {
   describe('constructor()', () => {
@@ -133,9 +133,10 @@ describe('File', () => {
   });
 
   describe('static fromDirent()', () => {
-    const argsToDirent = ([path, isDirectory]) => ({
+    const argsToDirent = ([path, isDirectory, isSymbolicLink]) => ({
       name: basename(path),
       isDirectory: () => isDirectory,
+      isSymbolicLink: () => isSymbolicLink,
     });
     const file1aDirent = argsToDirent(file1aArgs);
     const level2Dirent = argsToDirent(level2Args);
@@ -175,6 +176,24 @@ describe('File', () => {
         linkToUnexistingFileArgs[1],
       );
       expect(File.fromDirent(level1, unexistingFileDirent).isDirectory).toBe(unexistingFileArgs[1]);
+    });
+
+    it('it uses given dirent to determine isSymbolicLink', () => {
+      expect(File.fromDirent(level1, file1aDirent).isSymbolicLink).toBe(file1aArgs[2]);
+      expect(File.fromDirent(level1, level2Dirent).isSymbolicLink).toBe(level2Args[2]);
+      expect(File.fromDirent(level2, level3Dirent).isSymbolicLink).toBe(level3Args[2]);
+      expect(File.fromDirent(level1, linkToSiblingDirectoryDirent).isSymbolicLink).toBe(
+        linkToSiblingDirectoryArgs[2],
+      );
+      expect(File.fromDirent(level1, linkToSiblingFileDirent).isSymbolicLink).toBe(
+        linkToSiblingFileArgs[2],
+      );
+      expect(File.fromDirent(level1, linkToUnexistingFileDirent).isSymbolicLink).toBe(
+        linkToUnexistingFileArgs[2],
+      );
+      expect(File.fromDirent(level1, unexistingFileDirent).isSymbolicLink).toBe(
+        unexistingFileArgs[2],
+      );
     });
   });
 

--- a/src/files-by-directory.spec.js
+++ b/src/files-by-directory.spec.js
@@ -1,7 +1,7 @@
 import '@babel/polyfill'; // Required for NodeJS < 10
 import { values } from './async';
 import getFilesByDirectory from './files-by-directory';
-import { file1a, level2, level2Files, level3, level3Files } from '../fixture';
+import { file1a, level1, level2, level2Files, level3, level3Files } from '../fixture';
 
 /** @test {filesByDirectory} */
 describe('filesByDirectory', () => {
@@ -45,5 +45,29 @@ describe('filesByDirectory', () => {
     expect(await values(getFilesByDirectory(level3Files))).toMatchSnapshot();
     expect(await values(getFilesByDirectory([...level2Files, ...level3Files]))).toMatchSnapshot();
     expect(await values(getFilesByDirectory([...level3Files, ...level2Files]))).toMatchSnapshot();
+  });
+
+  describe('options', () => {
+    describe('excludeSymlinks', () => {
+      it('exclude symbolic links when excludeSymlinks is true', async () => {
+        const options = { excludeSymlinks: true };
+        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
+        expect(
+          await values(getFilesByDirectory([level3, ...level2Files], options)),
+        ).toMatchSnapshot();
+      });
+
+      it('includes symbolic links when excludeSymlinks is false', async () => {
+        const options = { excludeSymlinks: false };
+        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
+        expect(
+          await values(getFilesByDirectory([level3, ...level2Files], options)),
+        ).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,11 @@
+/**
+ * Default traversing options.
+ *
+ * @type {Object}
+ * @property {boolean} excludeSymlinks Whether to exclude symbolic links or not.
+ */
+const defaults = {
+  excludeSymlinks: false,
+};
+
+export default defaults;


### PR DESCRIPTION
# `excludeSymlinks` option (default: `false`)

When set to `true`, excludes symbolic links from results:

```bash
# Directory structure:
level1
├── level2a
│   ├── file2a
│   └── file2b
├── level2b -> level2a
├── file1a
└── file1b -> file1a
```

```js
for await (const files of filesByDirectory(['level1']/*, { excludeSymlinks: false }*/} )) {
  console.log(files);
}
// [ 'level1/level2b', 'level1/file1a', 'level1/file1b' ]
// [ 'level2a/file2a', 'level2a/file2b' ]

for await (const files of filesByDirectory(['level1'], { excludeSymlinks: true })) {
  console.log(files);
}
// [ 'level1/file1a', 'level1/file1b' ]
// [ 'level2a/file2a', 'level2a/file2b' ]
```