### PR TITLE
directoriesFirst option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-(nothing)
+- `directoriesFirst` option - [#8]
 
 ## [v0.2.0] - 2018-11-23
 
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file. The format 
 [#4]: https://github.com/amercier/files-by-directory/pull/4
 [#5]: https://github.com/amercier/files-by-directory/pull/5
 [#7]: https://github.com/amercier/files-by-directory/pull/7
+[#8]: https://github.com/amercier/files-by-directory/pull/8
 [v0.1.0]: https://github.com/amercier/files-by-directory/compare/v0.0.0...v0.1.0
 [v0.1.1]: https://github.com/amercier/files-by-directory/compare/v0.1.0...v0.1.1
 [v0.1.2]: https://github.com/amercier/files-by-directory/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ for await (const files of filesByDirectory(['level1'])) {
 
 ```
 [
-  'level1/level2/level3/file3a',
-  'level1/level2/level3/file3b'
+  'level1/file1a',
+  'level1/file1b'
 ]
 ---
 [
@@ -62,12 +62,12 @@ for await (const files of filesByDirectory(['level1'])) {
 ]
 ---
 [
-  'level1/level2b/file2b'
+  'level1/level2a/level3/file3a',
+  'level1/level2a/level3/file3b'
 ]
 ---
 [
-  'level1/file1a',
-  'level1/file1b'
+  'level1/level2b/file2b'
 ]
 ---
 ```
@@ -104,6 +104,39 @@ for await (const files of filesByDirectory(['level1'], { excludeSymlinks: true }
 }
 // [ 'level1/file1a', 'level1/file1b' ]
 // [ 'level2a/file2a', 'level2a/file2b' ]
+```
+
+#### `options.directoriesFirst` (default: `false`)
+
+When set to `true`, proceed directories (recursively) before files.
+
+```bash
+# Directory structure:
+level1
+├── level2
+│   ├── level3
+│   │   ├── file3a
+│   │   └── file3b
+│   ├── file2a
+│   └── file2b
+├── file1a
+└── file1b
+```
+
+```js
+for await (const files of filesByDirectory(['level1']/*, { directoriesFirst: false }*/} )) {
+  console.log(files);
+}
+// [ 'level1/file1a', 'level1/file1b' ]
+// [ 'level1/level2/file2a', 'level1/level2/file2b' ]
+// [ 'level1/level2/level3/file3a', 'level1/level2/level3/file3b' ]
+
+for await (const files of filesByDirectory(['level1'], { directoriesFirst: true })) {
+  console.log(files);
+}
+// [ 'level1/level2/level3/file3a', 'level1/level2/level3/file3b' ]
+// [ 'level1/level2/file2a', 'level1/level2/file2b' ]
+// [ 'level1/file1a', 'level1/file1b' ]
 ```
 
 ## Asynchronous iteration

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ When set to `true`, proceed directories (recursively) before files.
 ```bash
 # Directory structure:
 level1
-├── level2
+├── level2a
 │   ├── level3
 │   │   ├── file3a
 │   │   └── file3b
-│   ├── file2a
+│   └── file2a
+├── level2b
 │   └── file2b
 ├── file1a
 └── file1b
@@ -128,14 +129,16 @@ for await (const files of filesByDirectory(['level1']/*, { directoriesFirst: fal
   console.log(files);
 }
 // [ 'level1/file1a', 'level1/file1b' ]
-// [ 'level1/level2/file2a', 'level1/level2/file2b' ]
-// [ 'level1/level2/level3/file3a', 'level1/level2/level3/file3b' ]
+// [ 'level1/level2a/file2a' ]
+// [ 'level1/level2a/level3/file3a', 'level1/level2a/level3/file3b' ]
+// [ 'level1/level2b/file2b' ]
 
 for await (const files of filesByDirectory(['level1'], { directoriesFirst: true })) {
   console.log(files);
 }
-// [ 'level1/level2/level3/file3a', 'level1/level2/level3/file3b' ]
-// [ 'level1/level2/file2a', 'level1/level2/file2b' ]
+// [ 'level1/level2a/level3/file3a', 'level1/level2a/level3/file3b' ]
+// [ 'level1/level2a/file2a' ]
+// [ 'level1/level2b/file2b' ]
 // [ 'level1/file1a', 'level1/file1b' ]
 ```
 

--- a/src/__snapshots__/file.spec.js.snap
+++ b/src/__snapshots__/file.spec.js.snap
@@ -178,18 +178,6 @@ Array [
     File {
       "isDirectory": false,
       "isSymbolicLink": false,
-      "path": "fixture/level1/level2/level3/file3a",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
-      "path": "fixture/level1/level2/level3/file3b",
-    },
-  ],
-  Array [
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
       "path": "fixture/level1/level2/file2a",
     },
     File {
@@ -211,6 +199,18 @@ Array [
       "isDirectory": false,
       "isSymbolicLink": true,
       "path": "fixture/level1/level2/link-to-parent-directory",
+    },
+  ],
+  Array [
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/level3/file3a",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/level3/file3b",
     },
   ],
 ]
@@ -218,45 +218,6 @@ Array [
 
 exports[`File getFilesByDirectory() generates asynchronously one array of file instances per directory when file is a directory 3`] = `
 Array [
-  Array [
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
-      "path": "fixture/level1/level2/level3/file3a",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
-      "path": "fixture/level1/level2/level3/file3b",
-    },
-  ],
-  Array [
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
-      "path": "fixture/level1/level2/file2a",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": false,
-      "path": "fixture/level1/level2/file2b",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": true,
-      "path": "fixture/level1/level2/link-to-directory",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": true,
-      "path": "fixture/level1/level2/link-to-grand-parent-directory",
-    },
-    File {
-      "isDirectory": false,
-      "isSymbolicLink": true,
-      "path": "fixture/level1/level2/link-to-parent-directory",
-    },
-  ],
   Array [
     File {
       "isDirectory": false,
@@ -292,6 +253,45 @@ Array [
       "isDirectory": false,
       "isSymbolicLink": true,
       "path": "fixture/level1/link-to-unexisting-file",
+    },
+  ],
+  Array [
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/file2a",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/file2b",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": true,
+      "path": "fixture/level1/level2/link-to-directory",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": true,
+      "path": "fixture/level1/level2/link-to-grand-parent-directory",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": true,
+      "path": "fixture/level1/level2/link-to-parent-directory",
+    },
+  ],
+  Array [
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/level3/file3a",
+    },
+    File {
+      "isDirectory": false,
+      "isSymbolicLink": false,
+      "path": "fixture/level1/level2/level3/file3b",
     },
   ],
 ]

--- a/src/__snapshots__/files-by-directory.spec.js.snap
+++ b/src/__snapshots__/files-by-directory.spec.js.snap
@@ -20,15 +20,15 @@ Array [
 exports[`filesByDirectory generates one array per directory when given path is a directory containing sub-directories 1`] = `
 Array [
   Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
     "fixture/level1/level2/file2a",
     "fixture/level1/level2/file2b",
     "fixture/level1/level2/link-to-directory",
     "fixture/level1/level2/link-to-grand-parent-directory",
     "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;
@@ -77,15 +77,15 @@ Array [
 exports[`filesByDirectory omits descendant directory paths 1`] = `
 Array [
   Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
     "fixture/level1/level2/file2a",
     "fixture/level1/level2/file2b",
     "fixture/level1/level2/link-to-directory",
     "fixture/level1/level2/link-to-grand-parent-directory",
     "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;
@@ -93,15 +93,15 @@ Array [
 exports[`filesByDirectory omits descendant directory paths 2`] = `
 Array [
   Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
     "fixture/level1/level2/file2a",
     "fixture/level1/level2/file2b",
     "fixture/level1/level2/link-to-directory",
     "fixture/level1/level2/link-to-grand-parent-directory",
     "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;
@@ -141,7 +141,7 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 1`] = `
+exports[`filesByDirectory options directoriesFirst generates directories first when directoriesFirst is false 1`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -150,50 +150,64 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 2`] = `
+exports[`filesByDirectory options directoriesFirst generates directories first when directoriesFirst is false 2`] = `
 Array [
-  Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
   Array [
     "fixture/level1/level2/file2a",
     "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 3`] = `
+exports[`filesByDirectory options directoriesFirst generates directories first when directoriesFirst is false 3`] = `
 Array [
-  Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
-  ],
-  Array [
-    "fixture/level1/level2/file2a",
-    "fixture/level1/level2/file2b",
-  ],
   Array [
     "fixture/level1/file1a",
     "fixture/level1/file1b",
-  ],
-]
-`;
-
-exports[`filesByDirectory options excludeSymlinks exclude symbolic links when excludeSymlinks is true 4`] = `
-Array [
-  Array [
-    "fixture/level1/level2/level3/file3a",
-    "fixture/level1/level2/level3/file3b",
+    "fixture/level1/link-to-descendant-directory",
+    "fixture/level1/link-to-descendant-file",
+    "fixture/level1/link-to-sibling-directory",
+    "fixture/level1/link-to-sibling-file",
+    "fixture/level1/link-to-unexisting-file",
   ],
   Array [
     "fixture/level1/level2/file2a",
     "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 1`] = `
+exports[`filesByDirectory options directoriesFirst generates directories first when directoriesFirst is false 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options directoriesFirst generates files first when directoriesFirst is true 1`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -202,7 +216,7 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 2`] = `
+exports[`filesByDirectory options directoriesFirst generates files first when directoriesFirst is true 2`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -218,7 +232,7 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 3`] = `
+exports[`filesByDirectory options directoriesFirst generates files first when directoriesFirst is true 3`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -243,7 +257,7 @@ Array [
 ]
 `;
 
-exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 4`] = `
+exports[`filesByDirectory options directoriesFirst generates files first when directoriesFirst is true 4`] = `
 Array [
   Array [
     "fixture/level1/level2/level3/file3a",
@@ -255,6 +269,124 @@ Array [
     "fixture/level1/level2/link-to-directory",
     "fixture/level1/level2/link-to-grand-parent-directory",
     "fixture/level1/level2/link-to-parent-directory",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks excludes symbolic links when excludeSymlinks is true 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks excludes symbolic links when excludeSymlinks is true 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks excludes symbolic links when excludeSymlinks is true 3`] = `
+Array [
+  Array [
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks excludes symbolic links when excludeSymlinks is true 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 3`] = `
+Array [
+  Array [
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+    "fixture/level1/link-to-descendant-directory",
+    "fixture/level1/link-to-descendant-file",
+    "fixture/level1/link-to-sibling-directory",
+    "fixture/level1/link-to-sibling-file",
+    "fixture/level1/link-to-unexisting-file",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options excludeSymlinks includes symbolic links when excludeSymlinks is false 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
   ],
 ]
 `;

--- a/src/file.js
+++ b/src/file.js
@@ -57,15 +57,23 @@ export default class File {
   async *getFilesByDirectory(options = {}) {
     if (this.isDirectory) {
       const files = [];
+      const directories = [];
       for await (const child of this.getChildren(options)) {
         if (child.isDirectory) {
-          yield* child.getFilesByDirectory(options);
+          if (options.directoriesFirst) {
+            yield* child.getFilesByDirectory(options);
+          } else {
+            directories.push(child);
+          }
         } else {
           files.push(child);
         }
       }
       if (files.length > 0) {
         yield files;
+      }
+      for (const directory of directories) {
+        yield* directory.getFilesByDirectory(options);
       }
     } else {
       yield [this];

--- a/src/files-by-directory.js
+++ b/src/files-by-directory.js
@@ -19,10 +19,15 @@ import { isUniqueAndNotDescendant } from './path';
  */
 async function* fileObjectsByDirectory(paths, options = {}) {
   const regularFiles = {};
+  const directories = [];
 
   for await (const file of File.fromPaths(paths.filter(isUniqueAndNotDescendant))) {
     if (file.isDirectory) {
-      yield* file.getFilesByDirectory(options);
+      if (options.directoriesFirst) {
+        yield* file.getFilesByDirectory(options);
+      } else {
+        directories.push(file);
+      }
     } else if (!options.excludeSymlinks || !file.isSymbolicLink) {
       const parent = dirname(file.path);
       if (!regularFiles[parent]) {
@@ -34,6 +39,10 @@ async function* fileObjectsByDirectory(paths, options = {}) {
 
   for (const files of Object.values(regularFiles)) {
     yield files;
+  }
+
+  for (const directory of directories) {
+    yield* directory.getFilesByDirectory(options);
   }
 }
 

--- a/src/files-by-directory.spec.js
+++ b/src/files-by-directory.spec.js
@@ -1,6 +1,7 @@
 import '@babel/polyfill'; // Required for NodeJS < 10
 import { values } from './async';
 import getFilesByDirectory from './files-by-directory';
+import defaults from './options';
 import { file1a, level1, level2, level2Files, level3, level3Files } from '../fixture';
 
 /** @test {filesByDirectory} */
@@ -49,7 +50,11 @@ describe('filesByDirectory', () => {
 
   describe('options', () => {
     describe('excludeSymlinks', () => {
-      it('exclude symbolic links when excludeSymlinks is true', async () => {
+      it('is false by default', () => {
+        expect(defaults.excludeSymlinks).toBe(false);
+      });
+
+      it('excludes symbolic links when excludeSymlinks is true', async () => {
         const options = { excludeSymlinks: true };
         expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
         expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
@@ -61,6 +66,32 @@ describe('filesByDirectory', () => {
 
       it('includes symbolic links when excludeSymlinks is false', async () => {
         const options = { excludeSymlinks: false };
+        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
+        expect(
+          await values(getFilesByDirectory([level3, ...level2Files], options)),
+        ).toMatchSnapshot();
+      });
+    });
+
+    describe('directoriesFirst', () => {
+      it('is false by default', () => {
+        expect(defaults.excludeSymlinks).toBe(false);
+      });
+
+      it('generates files first when directoriesFirst is true', async () => {
+        const options = { directoriesFirst: true };
+        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
+        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
+        expect(
+          await values(getFilesByDirectory([level3, ...level2Files], options)),
+        ).toMatchSnapshot();
+      });
+
+      it('generates directories first when directoriesFirst is false', async () => {
+        const options = { directoriesFirst: false };
         expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
         expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
         expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();

--- a/src/options.js
+++ b/src/options.js
@@ -3,9 +3,11 @@
  *
  * @type {Object}
  * @property {boolean} excludeSymlinks Whether to exclude symbolic links or not.
+ * @property {boolean} directoriesFirst Whether to list directories before files.
  */
 const defaults = {
   excludeSymlinks: false,
+  directoriesFirst: false,
 };
 
 export default defaults;


### PR DESCRIPTION
# `directoriesFirst` option (default: `false`)

When set to `true`, proceed directories (recursively) before files.

```bash
# Directory structure:
level1
├── level2a
│   ├── level3
│   │   ├── file3a
│   │   └── file3b
│   └── file2a
├── level2b
│   └── file2b
├── file1a
└── file1b
```

```js
for await (const files of filesByDirectory(['level1']/*, { directoriesFirst: false }*/} )) {
  console.log(files);
}
// [ 'level1/file1a', 'level1/file1b' ]
// [ 'level1/level2a/file2a' ]
// [ 'level1/level2a/level3/file3a', 'level1/level2a/level3/file3b' ]
// [ 'level1/level2b/file2b' ]

for await (const files of filesByDirectory(['level1'], { directoriesFirst: true })) {
  console.log(files);
}
// [ 'level1/level2a/level3/file3a', 'level1/level2a/level3/file3b' ]
// [ 'level1/level2a/file2a' ]
// [ 'level1/level2b/file2b' ]
// [ 'level1/file1a', 'level1/file1b' ]
```