### PR TITLE
showDirectories option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 - `directoriesFirst` option - [#8]
+- `showDirectories` option - [#9]
 
 ## [v0.2.0] - 2018-11-23
 
@@ -48,6 +49,7 @@ All notable changes to this project will be documented in this file. The format 
 [#5]: https://github.com/amercier/files-by-directory/pull/5
 [#7]: https://github.com/amercier/files-by-directory/pull/7
 [#8]: https://github.com/amercier/files-by-directory/pull/8
+[#9]: https://github.com/amercier/files-by-directory/pull/9
 [v0.1.0]: https://github.com/amercier/files-by-directory/compare/v0.0.0...v0.1.0
 [v0.1.1]: https://github.com/amercier/files-by-directory/compare/v0.1.0...v0.1.1
 [v0.1.2]: https://github.com/amercier/files-by-directory/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -142,6 +142,40 @@ for await (const files of filesByDirectory(['level1'], { directoriesFirst: true 
 // [ 'level1/file1a', 'level1/file1b' ]
 ```
 
+#### `options.showDirectories` (default: `false`)
+
+When set to `true`, includes an entry containing the directory.
+
+```bash
+# Directory structure:
+level1
+├── level2
+│   ├── file2a
+│   └── file2b
+├── file1a
+└── file1b
+```
+
+```js
+for await (const files of filesByDirectory(['level1']/*, { showDirectories: false }*/} )) {
+  console.log(files);
+}
+// [ 'level1/file1a', 'level1/file1b' ]
+// [ 'level1/level2/file2a', 'level1/level2/file2b' ]
+
+for await (const files of filesByDirectory(['level1'], { showDirectories: true })) {
+  console.log(files);
+}
+// [ 'level1', 'level1/file1a', 'level1/file1b' ]
+// [ 'level1/level2', 'level1/level2/file2a', 'level1/level2/file2b' ]
+
+for await (const [directory, ...files] of filesByDirectory(['level1'], { showDirectories: true })) {
+  console.log(directory, files);
+}
+// level1 [ 'level1/file1a', 'level1/file1b' ]
+// level1/level2 [ 'level1/level2/file2a', 'level1/level2/file2b' ]
+```
+
 ## Asynchronous iteration
 
 [Asynchronous iteration] using `for-await-of` syntax requires Node 10+. For older version of NodeJS, either use:

--- a/src/__snapshots__/files-by-directory.spec.js.snap
+++ b/src/__snapshots__/files-by-directory.spec.js.snap
@@ -390,3 +390,142 @@ Array [
   ],
 ]
 `;
+
+exports[`filesByDirectory options showDirectories generates files with their directory when showDirectories is true 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3",
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files with their directory when showDirectories is true 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2",
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3",
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files with their directory when showDirectories is true 3`] = `
+Array [
+  Array [
+    "fixture/level1",
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+    "fixture/level1/link-to-descendant-directory",
+    "fixture/level1/link-to-descendant-file",
+    "fixture/level1/link-to-sibling-directory",
+    "fixture/level1/link-to-sibling-file",
+    "fixture/level1/link-to-unexisting-file",
+  ],
+  Array [
+    "fixture/level1/level2",
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3",
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files with their directory when showDirectories is true 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3",
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files without their directory when showDirectories is false 1`] = `
+Array [
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files without their directory when showDirectories is false 2`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files without their directory when showDirectories is false 3`] = `
+Array [
+  Array [
+    "fixture/level1/file1a",
+    "fixture/level1/file1b",
+    "fixture/level1/link-to-descendant-directory",
+    "fixture/level1/link-to-descendant-file",
+    "fixture/level1/link-to-sibling-directory",
+    "fixture/level1/link-to-sibling-file",
+    "fixture/level1/link-to-unexisting-file",
+  ],
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;
+
+exports[`filesByDirectory options showDirectories generates files without their directory when showDirectories is false 4`] = `
+Array [
+  Array [
+    "fixture/level1/level2/file2a",
+    "fixture/level1/level2/file2b",
+    "fixture/level1/level2/link-to-directory",
+    "fixture/level1/level2/link-to-grand-parent-directory",
+    "fixture/level1/level2/link-to-parent-directory",
+  ],
+  Array [
+    "fixture/level1/level2/level3/file3a",
+    "fixture/level1/level2/level3/file3b",
+  ],
+]
+`;

--- a/src/file.js
+++ b/src/file.js
@@ -54,13 +54,19 @@ export default class File {
    * @param {Object} options Traversing options, see {@link defaults}.
    * @returns {AsynchronousGenerator<File[]>} Generates one array of File instances per directory.
    */
-  async *getFilesByDirectory(options = {}) {
+  async *getFilesByDirectory({
+    directoriesFirst = defaults.directoriesFirst,
+    showDirectories = defaults.showDirectories,
+    ...otherOptions
+  } = {}) {
+    const options = { directoriesFirst, showDirectories, ...otherOptions };
+
     if (this.isDirectory) {
       const files = [];
       const directories = [];
       for await (const child of this.getChildren(options)) {
         if (child.isDirectory) {
-          if (options.directoriesFirst) {
+          if (directoriesFirst) {
             yield* child.getFilesByDirectory(options);
           } else {
             directories.push(child);
@@ -70,13 +76,13 @@ export default class File {
         }
       }
       if (files.length > 0) {
-        yield files;
+        yield showDirectories ? [this, ...files] : files;
       }
       for (const directory of directories) {
         yield* directory.getFilesByDirectory(options);
       }
     } else {
-      yield [this];
+      yield showDirectories ? [{}, this] : [this];
     }
   }
 

--- a/src/files-by-directory.spec.js
+++ b/src/files-by-directory.spec.js
@@ -49,29 +49,26 @@ describe('filesByDirectory', () => {
   });
 
   describe('options', () => {
+    async function testGetFilesByDirectoryWithOptions(options) {
+      expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
+      expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
+      expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
+      expect(
+        await values(getFilesByDirectory([level3, ...level2Files], options)),
+      ).toMatchSnapshot();
+    }
+
     describe('excludeSymlinks', () => {
       it('is false by default', () => {
         expect(defaults.excludeSymlinks).toBe(false);
       });
 
       it('excludes symbolic links when excludeSymlinks is true', async () => {
-        const options = { excludeSymlinks: true };
-        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
-        expect(
-          await values(getFilesByDirectory([level3, ...level2Files], options)),
-        ).toMatchSnapshot();
+        await testGetFilesByDirectoryWithOptions({ excludeSymlinks: true });
       });
 
       it('includes symbolic links when excludeSymlinks is false', async () => {
-        const options = { excludeSymlinks: false };
-        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
-        expect(
-          await values(getFilesByDirectory([level3, ...level2Files], options)),
-        ).toMatchSnapshot();
+        await testGetFilesByDirectoryWithOptions({ excludeSymlinks: false });
       });
     });
 
@@ -81,23 +78,25 @@ describe('filesByDirectory', () => {
       });
 
       it('generates files first when directoriesFirst is true', async () => {
-        const options = { directoriesFirst: true };
-        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
-        expect(
-          await values(getFilesByDirectory([level3, ...level2Files], options)),
-        ).toMatchSnapshot();
+        await testGetFilesByDirectoryWithOptions({ directoriesFirst: true });
       });
 
       it('generates directories first when directoriesFirst is false', async () => {
-        const options = { directoriesFirst: false };
-        expect(await values(getFilesByDirectory([level3], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level2], options))).toMatchSnapshot();
-        expect(await values(getFilesByDirectory([level1], options))).toMatchSnapshot();
-        expect(
-          await values(getFilesByDirectory([level3, ...level2Files], options)),
-        ).toMatchSnapshot();
+        await testGetFilesByDirectoryWithOptions({ directoriesFirst: false });
+      });
+    });
+
+    describe('showDirectories', () => {
+      it('is false by default', () => {
+        expect(defaults.showDirectories).toBe(false);
+      });
+
+      it('generates files with their directory when showDirectories is true', async () => {
+        await testGetFilesByDirectoryWithOptions({ showDirectories: true });
+      });
+
+      it('generates files without their directory when showDirectories is false', async () => {
+        await testGetFilesByDirectoryWithOptions({ showDirectories: false });
       });
     });
   });

--- a/src/options.js
+++ b/src/options.js
@@ -4,10 +4,13 @@
  * @type {Object}
  * @property {boolean} excludeSymlinks Whether to exclude symbolic links or not.
  * @property {boolean} directoriesFirst Whether to list directories before files.
+ * @property {boolean} showDirectories Whether to include directories as the first entry of the
+ * result arrays.
  */
 const defaults = {
   excludeSymlinks: false,
   directoriesFirst: false,
+  showDirectories: false,
 };
 
 export default defaults;


### PR DESCRIPTION
#### `options.showDirectories` (default: `false`)

When set to `true`, includes an entry containing the directory.

```bash
# Directory structure:
level1
├── level2
│   ├── file2a
│   └── file2b
├── file1a
└── file1b
```

```js
for await (const files of filesByDirectory(['level1']/*, { showDirectories: false }*/} )) {
  console.log(files);
}
// [ 'level1/file1a', 'level1/file1b' ]
// [ 'level1/level2/file2a', 'level1/level2/file2b' ]

for await (const files of filesByDirectory(['level1'], { showDirectories: true })) {
  console.log(files);
}
// [ 'level1', 'level1/file1a', 'level1/file1b' ]
// [ 'level1/level2', 'level1/level2/file2a', 'level1/level2/file2b' ]

for await (const [directory, ...files] of filesByDirectory(['level1'], { showDirectories: true })) {
  console.log(directory, files);
}
// level1 [ 'level1/file1a', 'level1/file1b' ]
// level1/level2 [ 'level1/level2/file2a', 'level1/level2/file2b' ]
```