### PR TITLE
Add ESM modules to distributed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "build:clean": "rimraf dist",
-    "build:transpile": "babel --ignore '**/*.spec.js' -d dist src",
+    "build:cjs": "babel --ignore '**/*.spec.js' --env-name CJS -d dist/cjs src",
+    "build:esm": "babel --ignore '**/*.spec.js' --env-name ESM -d dist/esm src",
     "build": "run-s build:*",
     "prepublishOnly": "run-s build",
     "doc:clean": "rimraf esdoc",
@@ -30,7 +31,8 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "keywords": [
     "list",
     "scan",
@@ -98,7 +100,35 @@
           }
         }
       ]
-    ]
+    ],
+    "env": {
+      "CJS": {
+        "presets": [
+          [
+            "@babel/preset-env",
+            {
+              "targets": {
+                "node": "6"
+              },
+              "modules": "commonjs"
+            }
+          ]
+        ]
+      },
+      "ESM": {
+        "presets": [
+          [
+            "@babel/preset-env",
+            {
+              "targets": {
+                "node": "6"
+              },
+              "modules": false
+            }
+          ]
+        ]
+      }
+    }
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
**TL;DR**: this PR adds support for `module` entry in `package.json`.

From [Pika website](https://www.pikapkg.com/about/):

> **Modern Code Runs Faster:**
> 
> [ES module syntax (ESM)](http://2ality.com/2014/09/es6-modules-final.html) is JavaScript’s modern native module system. Its `import` / `export` syntax is more compact, more easily analyzed, and more reliably optimized by build tooling like Webpack & Rollup. ES module dependencies result in smaller, faster JavaScript bundles.
>
> Unfortunately, most packages on npm are only published as [Common.js modules](http://eng.wealthfront.com/2015/06/16/an-introduction-to-commonjs/) using Node’s native `require()` and `module.exports` syntax. Bundlers have a more difficult time analyzing & optimizing these modules. Plus they’re more likely to be filled with slow transpiler bloat only needed for old versions of Node.js.
> 
> How do you know which of these two systems your favorite package is using? Well, it’s not always obvious. Modern packages work by defining an ESM [“module”](https://github.com/rollup/rollup/wiki/pkg.module) build in their `package.json` manifest. But [npmjs.com](https://www.npmjs.com/) and other package search engines don’t readily show this. Before now, this left us digging through GitHub repos & source code.
>
> That’s why [pikapkg.com](https://www.pikapkg.com/) was created. Use the search bar at the top of the page to find fast, modern, native ESM packages that match your keywords. Your results will only include packages that are built with modern ESM syntax & include a defined `"module"` entry point in their `package.json` manifest.

 